### PR TITLE
fix: mysql dialect support (ilike exclusivity issue) 

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,6 @@
 NODE_ENV=test
-POSTGRES_USER="adminbro"
-POSTGRES_PASSWORD="adminbro"
-POSTGRES_DATABASE="adminbro-sequelize-test"
-POSTGRES_HOST
-POSTGRES_PORT
+DATABASE_USER="adminbro"
+DATABASE_PASSWORD="adminbro"
+DATABASE_NAME="adminbro-sequelize-test"
+DATABASE_HOST
+DATABASE_PORT

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,11 +34,11 @@ jobs:
       postgres:
         image: postgres:10.8
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
+          DATABASE_USER: postgres
+          DATABASE_PASSWORD: postgres
+          DATABASE_DB: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
@@ -61,18 +61,18 @@ jobs:
       - run: yarn run sequelize db:migrate
         env:
           NODE_ENV: test
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DATABASE: postgres
-          POSTGRES_USER: postgres
+          DATABASE_PASSWORD: postgres
+          DATABASE_NAME: postgres
+          DATABASE_USER: postgres
       - name: Lint
         run: yarn lint
       - name: test
         run: yarn test
         env:
           NODE_ENV: test
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DATABASE: postgres
-          POSTGRES_USER: postgres
+          DATABASE_PASSWORD: postgres
+          DATABASE_NAME: postgres
+          DATABASE_USER: postgres
       - name: Build
         run: yarn build
       - name: Release
@@ -83,7 +83,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: yarn release
 
-  notify: 
+  notify:
     name: Notify
     runs-on: ubuntu-latest
     if: always()
@@ -100,5 +100,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: failure()
-
-      

--- a/README.md
+++ b/README.md
@@ -7,18 +7,17 @@ This is an official [AdminBro](https://github.com/SoftwareBrothers/admin-bro) ad
 The plugin can be registered using standard `AdminBro.registerAdapter` method.
 
 ```javascript
-const AdminBro = require('admin-bro')
-const AdminBroSequelize = require('@admin-bro/sequelize')
+const AdminBro = require('admin-bro');
+const AdminBroSequelize = require('@admin-bro/sequelize');
 
-AdminBro.registerAdapter(AdminBroSequelize)
+AdminBro.registerAdapter(AdminBroSequelize);
 ```
 
 More options can be found on [AdminBro](https://github.com/SoftwareBrothers/admin-bro) official website.
 
 ## Testing
 
-Integration tests require running database. Database connection data are  given in `config/config.js`. Make sure you have following env variables set: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_PORT, POSTGRES_DATABASE, POSTGRES_HOST. Take a look at `config/config.js` to see default values.
-
+Integration tests require running database. Database connection data are given in `config/config.js`. Make sure you have following env variables set: `DATABASE_USER`, `DATABASE_PASSWORD`, `DATABASE_PORT`, `DATABASE_NAME`, `DATABASE_HOST`, `DATABASE_DIALECT`. Take a look at `config/config.js` to see default values.
 
 Than you will have to create database and run migrations
 
@@ -35,8 +34,7 @@ AdminBro is Copyright © 2018 SoftwareBrothers.co. It is free software, and may 
 
 <img src="https://softwarebrothers.co/assets/images/software-brothers-logo-full.svg" width=240>
 
-
 We’re an open, friendly team that helps clients from all over the world to transform their businesses and create astonishing products.
 
-* We are available to [hire](https://softwarebrothers.co/contact).
-* If you want to work for us - checkout the [career page](https://softwarebrothers.co/career).
+- * We are available to [hire](https://softwarebrothers.co/contact).
+- * If you want to work for us - checkout the [career page](https://softwarebrothers.co/career).

--- a/config/config.js
+++ b/config/config.js
@@ -1,11 +1,11 @@
 module.exports = {
   test: {
-    username: process.env.POSTGRES_USER,
-    password: process.env.POSTGRES_PASSWORD,
-    port: process.env.POSTGRES_PORT || 5432,
-    database: process.env.POSTGRES_DATABASE || 'database_test',
-    host: process.env.POSTGRES_HOST || 'localhost',
-    dialect: 'postgres',
+    username: process.env.DATABASE_USER,
+    password: process.env.DATABASE_PASSWORD,
+    port: process.env.DATABASE_PORT || 5432,
+    database: process.env.DATABASE_NAME || 'database_test',
+    host: process.env.DATABASE_HOST || 'localhost',
+    dialect: process.env.DATABASE_DIALECT || 'postgres',
     logging: false,
   },
 }

--- a/example-app/.env-example
+++ b/example-app/.env-example
@@ -1,4 +1,4 @@
 NODE_ENV=test
-POSTGRES_USER="adminbro"
-POSTGRES_PASSWORD="adminbro"
-POSTGRES_DATABASE="adminbro-sequelize"
+DATABASE_USER="adminbro"
+DATABASE_PASSWORD="adminbro"
+DATABASE_NAME="adminbro-sequelize"

--- a/example-app/src/connect.ts
+++ b/example-app/src/connect.ts
@@ -4,11 +4,11 @@ import buildUser from './users/user.entity'
 import buildComment from './comments/comment.entity'
 
 const connect = async (): Promise<Sequelize> => {
-  const dbName = process.env.POSTGRES_DATABASE || 'adminbro-sequelize'
-  const host = process.env.POSTGRES_HOST || 'localhost'
-  const password = process.env.POSTGRES_PASSWORD || 'adminbro'
-  const user = process.env.POSTGRES_USER || 'adminbro'
-  const port = process.env.POSTGRES_PORT || 5432
+  const dbName = process.env.DATABASE_NAME || 'adminbro-sequelize'
+  const host = process.env.DATABASE_HOST || 'localhost'
+  const password = process.env.DATABASE_PASSWORD || 'adminbro'
+  const user = process.env.DATABASE_USER || 'adminbro'
+  const port = process.env.DATABASE_PORT || 5432
 
   const sequelize = new Sequelize(
     `postgres://${user}:${password}@${host}:${port}/${dbName}`,

--- a/migrations/20181211174223-create-user.js
+++ b/migrations/20181211174223-create-user.js
@@ -1,6 +1,6 @@
 const GENDER_CHOICES = {
-  MALE: "male",
-  FEMALE: "female",
+  MALE: 'male',
+  FEMALE: 'female',
 }
 
 module.exports = {
@@ -26,9 +26,9 @@ module.exports = {
       email: {
         type: Sequelize.STRING,
       },
-      arrayed: {
-        type: Sequelize.ARRAY(Sequelize.STRING),
-      },
+      ...(process.env.DATABASE_DIALECT === 'postgres'
+        ? { arrayed: { type: Sequelize.ARRAY(Sequelize.STRING) } }
+        : {}),
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE,
@@ -39,5 +39,5 @@ module.exports = {
       },
     })
   },
-  down: queryInterface => queryInterface.dropTable('Users'),
+  down: (queryInterface) => queryInterface.dropTable('Users'),
 }

--- a/migrations/20191216175344-create-post.js
+++ b/migrations/20191216175344-create-post.js
@@ -1,5 +1,3 @@
-
-
 module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.createTable('Posts', {
     id: {

--- a/models/user.js
+++ b/models/user.js
@@ -11,7 +11,9 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       validate: { isEmail: true },
     },
-    arrayed: DataTypes.ARRAY(DataTypes.STRING),
+    ...(process.env.DATABASE_DIALECT === 'postgres'
+      ? { arrayed: DataTypes.ARRAY(DataTypes.STRING) }
+      : {}),
   }, {})
   User.associate = function (models) {
     User.hasMany(models.Post, { foreignKey: 'userId' })

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "husky": "^4.2.5",
     "mocha": "^5.2.0",
+    "mysql2": "^2.2.5",
     "nyc": "^12.0.2",
     "pg": "^7.7.1",
     "semantic-release": "^17.0.7",

--- a/src/database.spec.ts
+++ b/src/database.spec.ts
@@ -3,6 +3,7 @@ import Sequelize from 'sequelize'
 import chai, { expect } from 'chai'
 import sinonChai from 'sinon-chai'
 
+import isPostgres from './utils/is-postgres'
 import Database from './database'
 import Resource from './resource'
 import db from '../models/index.js'
@@ -18,7 +19,7 @@ describe('Database', () => {
       firstName: Sequelize.STRING,
       lastName: Sequelize.STRING,
       email: Sequelize.STRING,
-      arrayed: Sequelize.ARRAY(Sequelize.STRING),
+      ...(isPostgres() ? { arrayed: Sequelize.ARRAY(Sequelize.STRING) } : {}),
     }, {})
   })
 

--- a/src/property.spec.ts
+++ b/src/property.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import chai, { expect } from 'chai'
 import sinonChai from 'sinon-chai'
+import isPostgres from './utils/is-postgres'
 import { AvailableTestModels } from './utils/available-test-models'
 
 import Property from './property'
@@ -22,10 +23,12 @@ describe('Property', () => {
       expect(property.isArray()).to.equal(false)
     })
 
-    it('returns true for array property', () => {
-      const property = new Property(getRawProperty('User', 'arrayed'))
-      expect(property.isArray()).to.equal(true)
-    })
+    if (isPostgres()) {
+      it('returns true for array property', () => {
+        const property = new Property(getRawProperty('User', 'arrayed'))
+        expect(property.isArray()).to.equal(true)
+      })
+    }
   })
 
   describe('#type', () => {
@@ -44,10 +47,12 @@ describe('Property', () => {
       expect(property.type()).to.equal('datetime')
     })
 
-    it('returns string when property is an array of strings', () => {
-      const property = new Property(getRawProperty('User', 'arrayed'))
-      expect(property.type()).to.equal('string')
-    })
+    if (isPostgres()) {
+      it('returns string when property is an array of strings', () => {
+        const property = new Property(getRawProperty('User', 'arrayed'))
+        expect(property.type()).to.equal('string')
+      })
+    }
   })
 
   describe('#availableValues', () => {

--- a/src/resource.spec.ts
+++ b/src/resource.spec.ts
@@ -5,6 +5,7 @@ import chai, { expect } from 'chai'
 import sinonChai from 'sinon-chai'
 import sinon from 'sinon'
 
+import isPostgres from './utils/is-postgres'
 import Resource, { ModelType } from './resource'
 import Property from './property'
 
@@ -58,7 +59,8 @@ describe('Resource', function () {
 
   describe('#properties', () => {
     it('returns all properties', function () {
-      const length = 8 // there are 8 properties in the User model (5 regular + __v and _id)
+      // there are 7 or 8 (postgres array) properties in the User model (5 regular + __v and _id)
+      const length = isPostgres() ? 8 : 7
       expect(resource.properties()).to.have.lengthOf(length)
     })
   })
@@ -72,12 +74,14 @@ describe('Resource', function () {
       expect(resource.property('some.imagine.property')).to.be.null
     })
 
-    it('returns nested property for array field', function () {
-      const property = resource.property('arrayed.1')
+    if (isPostgres()) {
+      it('returns nested property for array field', function () {
+        const property = resource.property('arrayed.1')
 
-      expect(property).to.be.an.instanceOf(Property)
-      expect(property?.type()).to.equal('string')
-    })
+        expect(property).to.be.an.instanceOf(Property)
+        expect(property?.type()).to.equal('string')
+      })
+    }
   })
 
   describe('#findMany', () => {
@@ -214,7 +218,7 @@ describe('Resource', function () {
           userId: '',
         }
         this.recordParams = await resource.create(this.params)
-        expect(this.recordParams.userId).to.be.null
+        expect(this.recordParams.userId).to.be.oneOf([null, undefined])
       })
     })
   })

--- a/src/utils/convert-filter.ts
+++ b/src/utils/convert-filter.ts
@@ -1,5 +1,5 @@
 import escape from 'escape-regexp'
-import {
+import Sequelize, {
   Op,
 } from 'sequelize'
 
@@ -36,11 +36,12 @@ const convertFilter = (filter) => {
         ...memo,
         [Op.and]: [
           ...(memo[Op.and] || []),
-          {
-            [property.name()]: {
-              [Op.iLike as unknown as string]: `%${escape(value)}%`,
+          Sequelize.where(
+            Sequelize.fn('lower', Sequelize.col(`${property.name()}`)),
+            {
+              [Op.like]: `%${escape(`${value}`.toLowerCase())}%`,
             },
-          },
+          ),
         ],
       }
     }

--- a/src/utils/is-postgres.ts
+++ b/src/utils/is-postgres.ts
@@ -1,0 +1,3 @@
+export default function isPostgres(): boolean {
+  return process.env.DATABASE_DIALECT === 'postgres'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3418,6 +3418,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+denque@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.0.tgz#773de0686ff2d8ec2ff92914316a47b73b1c73de"
+  integrity sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==
+
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
@@ -4386,6 +4391,13 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+generate-function@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
+  dependencies:
+    is-property "^1.0.2"
+
 genfun@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
@@ -4839,6 +4851,13 @@ i18next@^19.1.0:
   dependencies:
     "@babel/runtime" "^7.3.1"
 
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -5274,6 +5293,11 @@ is-primitive@^2.0.0:
 is-promise@^2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-property@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
 
 is-redirect@^1.0.0:
   version "1.0.0"
@@ -6011,6 +6035,11 @@ lolex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.0.0.tgz#f04ee1a8aa13f60f1abd7b0e8f4213ec72ec193e"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 longest-streak@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
@@ -6048,6 +6077,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 lru-queue@0.1:
   version "0.1.0"
@@ -6502,6 +6538,27 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mysql2@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-2.2.5.tgz#72624ffb4816f80f96b9c97fedd8c00935f9f340"
+  integrity sha512-XRqPNxcZTpmFdXbJqb+/CtYVLCx14x1RTeNMD4954L331APu75IC74GDqnZMEt1kwaXy6TySo55rF2F3YJS78g==
+  dependencies:
+    denque "^1.4.1"
+    generate-function "^2.3.1"
+    iconv-lite "^0.6.2"
+    long "^4.0.0"
+    lru-cache "^6.0.0"
+    named-placeholders "^1.1.2"
+    seq-queue "^0.0.5"
+    sqlstring "^2.3.2"
+
+named-placeholders@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/named-placeholders/-/named-placeholders-1.1.2.tgz#ceb1fbff50b6b33492b5cf214ccf5e39cef3d0e8"
+  integrity sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==
+  dependencies:
+    lru-cache "^4.1.3"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -8519,7 +8576,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
@@ -8625,6 +8682,11 @@ semver@^7.1.2, semver@^7.2.1, semver@^7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+seq-queue@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/seq-queue/-/seq-queue-0.0.5.tgz#d56812e1c017a6e4e7c3e3a37a1da6d78dd3c93e"
+  integrity sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4=
+
 sequelize-cli@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/sequelize-cli/-/sequelize-cli-6.2.0.tgz#fd02bfeae23b8226872f9947f3f8212cc49a4771"
@@ -8644,14 +8706,14 @@ sequelize-pool@^6.0.0:
   integrity sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==
 
 sequelize@>4.42.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.4.0.tgz#02c7e06aa7371488c23f110cdd7e4c2666d92142"
-  integrity sha512-XiSAaYMidgLHgOFz0d0rMlSXP07YoL3GwuG0KTtXR6moR+lfdAA93vhLaN9K6f1ElLMutNTx2f7bNK6mACYfIA==
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.3.5.tgz#80e3db7ac8b76d98c45ca93334197eb6e2335158"
+  integrity sha512-MiwiPkYSA8NWttRKAXdU9h0TxP6HAc1fl7qZmMO/VQqQOND83G4nZLXd0kWILtAoT9cxtZgFqeb/MPYgEeXwsw==
   dependencies:
     debug "^4.1.1"
     dottie "^2.0.0"
     inflection "1.12.0"
-    lodash "^4.17.20"
+    lodash "^4.17.15"
     moment "^2.26.0"
     moment-timezone "^0.5.31"
     retry-as-promised "^3.2.0"
@@ -8974,6 +9036,11 @@ split@^1.0.0:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+sqlstring@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.2.tgz#cdae7169389a1375b18e885f2e60b3e460809514"
+  integrity sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -10105,6 +10172,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.7.2:
   version "1.10.0"


### PR DESCRIPTION
**BREAKING** (due to env vars)

[Fork's PR](https://github.com/beInDev/admin-bro-sequelizejs/pull/1/)
Adds compatibility for mysql sequelize dialect by removing the use of the dialect specific operator iLIKE and adding conditional use of arrayed types