### PR TITLE
fix: remove check for auto increment on isId/isEditable

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -50,9 +50,6 @@ class Property extends BaseProperty {
     if (this.sequelizePath.autoIncrement) {
       return false
     }
-    if (this.isId()) {
-      return false
-    }
     return true
   }
 


### PR DESCRIPTION
Currently if a table has a primary key (ID) without the auto-increment attribute, AdminBro – and this sequelize adapter – will not allow to edit that field.

Trying to show the attribute in the creation and edit form will fail, as all primary keys are currently marked as non editable. 

This PR changes the behaviour, but keep backward compatibility for any primary key with auto-increment set. 

If instead the auto-increment is not set on the primary key, then the field will automatically appear and become editable. Which is what anyone would expect AFAIK, as otherwise trying to insert a record (without being able to specify the value of the field) will throw an error.

Fix https://github.com/SoftwareBrothers/admin-bro/issues/544
